### PR TITLE
Add AppConfig.

### DIFF
--- a/fluent_pages/__init__.py
+++ b/fluent_pages/__init__.py
@@ -1,2 +1,3 @@
 # following PEP 440
 __version__ = "0.9"
+default_app_config = 'fluent_pages.apps.FluentPagesConfig'

--- a/fluent_pages/apps.py
+++ b/fluent_pages/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class FluentPagesConfig(AppConfig):
+    name = 'fluent_pages'
+    verbose_name = 'Fluent Pages'


### PR DESCRIPTION
In Django>=1.7 an AppConfig may be declared allowing for app configuration (https://docs.djangoproject.com/en/1.8/ref/applications/).

This will allow functionality to modify app name labels in the admin.