### PR TITLE
Fix typo for template tag call.

### DIFF
--- a/fluent_pages/templates/fluent_pages/example-cmspage.html
+++ b/fluent_pages/templates/fluent_pages/example-cmspage.html
@@ -1,4 +1,4 @@
-{% load fluent_page_tags fluent_contents_tags %}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+{% load fluent_pages_tags fluent_contents_tags %}<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 
 <html xml:lang="{{ LANGUAGE_CODE|default:"nl" }}" lang="{{ LANGUAGE_CODE|default:"nl" }}">
   <head>


### PR DESCRIPTION
Typo in the `example-cmspage.html` file where it calls the template tag `fluent_page_tags` the template tag is actually `fluent_pages_tags`.