### PR TITLE
Bind to document to capture JS created related-lookup classes.

### DIFF
--- a/fluent_pages/templates/admin/fluent_pages/page/base_change_form.html
+++ b/fluent_pages/templates/admin/fluent_pages/page/base_change_form.html
@@ -65,11 +65,11 @@
     <script type="text/javascript">
         (function($) {
             $(document).ready(function() {
-                $('.add-another').click(function(e) {
+                $(document).on('click', '.add-another', function(e) {
                     e.preventDefault();
                     showAddAnotherPopup(this);
                 });
-                $('.related-lookup').click(function(e) {
+                $(document).on('click', '.related-lookup', function(e) {
                     e.preventDefault();
                     showRelatedObjectLookupPopup(this);
                 });


### PR DESCRIPTION
When creating a new content instance with a content plugin containing a raw ID it does not use the popup=1 parameter as the `$('.related-lookup')` binding has already been completed. Changing this to `$(document).on('click', 'add-another',` will bind for all occurrences created.

I have changed `.add-another` to be consistent.