### PR TITLE
fix welcome.json fixture

### DIFF
--- a/example/fixtures/welcome.json
+++ b/example/fixtures/welcome.json
@@ -58,9 +58,6 @@
   "pk": 1,
   "model": "fluentpage.fluentpage",
   "fields": {
-    "meta_description": "",
-    "meta_title": null,
-    "meta_keywords": "",
     "layout": 1
   }
 },


### PR DESCRIPTION
fix "FluentPage has no field named u'meta_description'" error