### PR TITLE
Fix filter_site typo in UrlNodeParentAdmin.

### DIFF
--- a/fluent_pages/adminui/urlnodeparentadmin.py
+++ b/fluent_pages/adminui/urlnodeparentadmin.py
@@ -41,7 +41,7 @@ class UrlNodeParentAdmin(MultiSiteAdminMixin, TranslatableAdmin, PolymorphicMPTT
     The internal machinery
     The admin screen for the ``UrlNode`` objects.
     """
-    filter_sites = appsettings.FLUENT_PAGES_FILTER_SITE_ID
+    filter_site = appsettings.FLUENT_PAGES_FILTER_SITE_ID
     base_model = UrlNode
     add_type_form = PageTypeChoiceForm
 


### PR DESCRIPTION
This change is needed to ensure that the `FLUENT_PAGES_FILTER_SITE_ID` setting works correctly.
