### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -236,7 +236,7 @@ please let us know as well because we will look into it.
 Pull requests are welcome too. :-)
 
 
-.. _documentation: http://django-fluent-pages.readthedocs.org/
+.. _documentation: https://django-fluent-pages.readthedocs.io/
 .. _django.contrib.sites: https://docs.djangoproject.com/en/dev/ref/contrib/sites/
 .. _django.contrib.sitemaps: https://docs.djangoproject.com/en/dev/ref/contrib/sitemaps/
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -258,7 +258,7 @@ texinfo_documents = [
 intersphinx_mapping = {
     'http://docs.python.org/': None,
     'https://docs.djangoproject.com/en/dev': 'https://docs.djangoproject.com/en/dev/_objects',
-    'anyurlfield': ('http://django-any-urlfield.readthedocs.org/en/latest/', None),
-    'fluentcontents': ('http://django-fluent-contents.readthedocs.org/en/latest/', None),
-    'parler': ('http://django-parler.readthedocs.org/en/latest/', None),
+    'anyurlfield': ('https://django-any-urlfield.readthedocs.io/en/latest/', None),
+    'fluentcontents': ('https://django-fluent-contents.readthedocs.io/en/latest/', None),
+    'parler': ('https://django-parler.readthedocs.io/en/latest/', None),
 }

--- a/docs/pagetypes/flatpage.rst
+++ b/docs/pagetypes/flatpage.rst
@@ -147,7 +147,7 @@ Additional editors can be easily added, as the setting refers to a set of templa
 * django_wysiwyg/**flavor**/editor_instance.html
 
 For more information, see the documentation of django-wysiwyg_
-about `extending django-wysiwyg <http://django-wysiwyg.readthedocs.org/en/latest/extending.html>`_.
+about `extending django-wysiwyg <https://django-wysiwyg.readthedocs.io/en/latest/extending.html>`_.
 
 
 FLUENT_TEXT_CLEAN_HTML

--- a/docs/pagetypes/fluentpage.rst
+++ b/docs/pagetypes/fluentpage.rst
@@ -112,4 +112,4 @@ which can be used as base classes for :ref:`custom page types <newpagetypes>`
 that also use the same layout mechanisms.
 
 
-.. _django-fluent-contents: http://django-fluent-contents.readthedocs.org/en/latest/
+.. _django-fluent-contents: https://django-fluent-contents.readthedocs.io/en/latest/

--- a/docs/pagetypes/redirectnode.rst
+++ b/docs/pagetypes/redirectnode.rst
@@ -47,4 +47,4 @@ See the :mod:`anyurlfield:any_urlfield.models` documentation for details.
 
 
 
-.. _django-any-urlfield: http://django-any-urlfield.readthedocs.org/en/latest/
+.. _django-any-urlfield: https://django-any-urlfield.readthedocs.io/en/latest/

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -308,6 +308,6 @@ Testing your new shiny project
 Congrats! At this point you should have a working installation.
 Now you can just login to your admin site and see what changed.
 
-.. _django-fluent-contents: http://django-fluent-contents.readthedocs.org/en/latest/
+.. _django-fluent-contents: https://django-fluent-contents.readthedocs.io/en/latest/
 .. _django-polymorphic-tree: https://github.com/edoburu/django-polymorphic-tree
 .. _django-wysiwyg: https://github.com/pydanny/django-wysiwyg/

--- a/fluent_pages/pagetypes/fluentpage/admin.py
+++ b/fluent_pages/pagetypes/fluentpage/admin.py
@@ -36,7 +36,7 @@ class FluentPageAdmin(FluentContentsPageAdmin):
         In fact, the code in this class concerns with the layout mechanism that is specific for this implementation.
 
     To build a variation of this page, see the API documentation
-    of `Creating a CMS system <http://django-fluent-contents.readthedocs.org/en/latest/cms.html>`_
+    of `Creating a CMS system <https://django-fluent-contents.readthedocs.io/en/latest/cms.html>`_
     in the *django-fluent-contents* documentation to implement the required API's.
     """
     base_form = FluentPageAdminForm

--- a/fluent_pages/templates/fluent_pages/intro_page.html
+++ b/fluent_pages/templates/fluent_pages/intro_page.html
@@ -47,14 +47,14 @@
     <p>See the documentation to get started:</p>
     <ul>
       <li><a href="http://django-fluent.org/">main website</a></li>
-      <li><a href=https://django-fluent-pages.readthedocs.org/>documentation</a></li>
+      <li><a href=https://django-fluent-pages.readthedocs.io/>documentation</a></li>
     </ul>
 
     <div class="addons">
       <p>Addons:</p>
       <ul>
-        <li><a href=https://django-fluent-contents.readthedocs.org/>django-fluent-contents</a> - flexible content blocks</li>
-        <li><a href=https://django-fluent-dashboard.readthedocs.org/>django-fluent-dashboard</a> - admin dashboard</li>
+        <li><a href=https://django-fluent-contents.readthedocs.io/>django-fluent-contents</a> - flexible content blocks</li>
+        <li><a href=https://django-fluent-dashboard.readthedocs.io/>django-fluent-dashboard</a> - admin dashboard</li>
         <li><a href=https://github.com/edoburu/django-fluent-blogs/blob/master/README.rst>django-fluent-blogs</a> - blog engine</li>
         <li><a href=https://github.com/edoburu/django-fluent-faq/blob/master/README.rst>django-fluent-faq</a> - faq engine</li>
         <li><a href=https://github.com/edoburu/django-fluent-comments/blob/master/README.rst>django-fluent-comments</a> - comments module</li>


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.